### PR TITLE
Adding ability to record frames from simulator for making videos

### DIFF
--- a/pyrosim/simulator/datastruct.h
+++ b/pyrosim/simulator/datastruct.h
@@ -19,6 +19,7 @@ struct Data
   int followBody;
   int collisionMatrix[MAX_GROUPS][MAX_GROUPS];
   int numCollisionGroups;
+  int capture;
 };
 
 #endif

--- a/pyrosim/simulator/environment.cpp
+++ b/pyrosim/simulator/environment.cpp
@@ -106,6 +106,12 @@ void ENVIRONMENT::Read_From_Python(dWorldID world, dSpaceID space, Data *data)
                         std::cin >> data->followBody;
                 else if ( strcmp(incomingString,"TrackBody")==0)
                         std::cin >> data->trackBody;
+
+                else if ( strcmp(incomingString,"Capture")==0)
+                {
+                		std::cin >> data->capture;
+                }
+
                 //Collision data
                 else if ( strcmp(incomingString,"CollisionMatrix")==0){
                         std::cin >> data->numCollisionGroups;


### PR DESCRIPTION
Put in my old code for recording frames from draw stuff.   This is based on giving an option 'capture=frequency' ' to the Simulator initializer where frequency is how often you want frames to be written.  E.g. capture=1 will write every frame to file.  

Frames are written as frame/%04d.ppm under the current directory (frame directory will be created if it doesn't exist, and any existing files in there will be removed before saving new files).